### PR TITLE
a smoll typo.

### DIFF
--- a/src/cogs/events/main.py
+++ b/src/cogs/events/main.py
@@ -88,6 +88,6 @@ class MainEvents(Cog, name="Main Events"):
     async def on_mention(self, ctx):
         prefix = self.bot.guild_data[ctx.guild.id]["prefix"] or "q"
         await ctx.send(
-            f"{random_greeting()}, You seem lost. Are you?\n"
+            f"{random_greeting()} You seem lost. Are you?\n"
             f"Current prefix for this server is: `{prefix}`.\n\nUse it like: `{prefix}help`"
         )


### PR DESCRIPTION
All the greetings end with some kind of marks like exclamation or full stop, so there is no need of a `comma` there.