### PR TITLE
[core] fixed returning `True` from `get_or_fetch_message`

### DIFF
--- a/src/core/Bot.py
+++ b/src/core/Bot.py
@@ -282,7 +282,7 @@ class Quotient(commands.AutoShardedBot):
         self, channel: discord.TextChannel, message_id: int, *, cache: bool=True, fetch: bool=True
     ) -> Optional[discord.Message]:
         # caching cause, due to rate limiting 50/1
-        if msg := self.get_message(message_id) and cache:
+        if cache and (msg := self.get_message(message_id)):
             return msg
         try:
             return self.message_cache[message_id]


### PR DESCRIPTION
This happen when the cached message is not found

```python
>>> (x := 1 and True)
True
>>> (True and (x := 1))
1
```