### PR TITLE
Fix 100 :: Add listener to delete EasyTag and TagCheck records on channel deletion

### DIFF
--- a/src/cogs/esports/events/tags.py
+++ b/src/cogs/esports/events/tags.py
@@ -116,16 +116,22 @@ class TagEvents(Cog):
     async def on_channel_delete(self, channel: discord.abc.GuildChannel) -> None:
         if not isinstance(channel, discord.TextChannel):
             return
+
         channel_id = channel.id
 
         # Delete EasyTag record if exists
-        easytag = await EasyTag.get_or_none(channel_id=channel_id)
-        if easytag:
-            await easytag.delete()
+        if channel_id in self.bot.cache.eztagchannels:
+            easytag = await EasyTag.get_or_none(channel_id=channel_id)
+            if easytag:
+                await easytag.delete()
+            self.bot.cache.eztagchannels.remove(channel_id)
 
         # Delete TagCheck record if exists
-        tagcheck = await TagCheck.get_or_none(channel_id=channel_id)
-        if tagcheck:
-            await tagcheck.delete()
+        if channel_id in self.bot.cache.tagcheck:
+            tagcheck = await TagCheck.get_or_none(channel_id=channel_id)
+            if tagcheck:
+                await tagcheck.delete()
+            self.bot.cache.tagcheck.remove(channel_id)
+
 
 

--- a/src/cogs/esports/events/tags.py
+++ b/src/cogs/esports/events/tags.py
@@ -113,7 +113,9 @@ class TagEvents(Cog):
                 self.bot.loop.create_task(delete_denied_message(msg, 60))
 
     @Cog.listener(name="on_guild_channel_delete")
-    async def on_channel_delete(self, channel: discord.TextChannel):
+    async def on_channel_delete(self, channel: discord.abc.GuildChannel) -> None:
+        if not isinstance(channel, discord.TextChannel):
+            return
         channel_id = channel.id
 
         # Delete EasyTag record if exists
@@ -125,4 +127,5 @@ class TagEvents(Cog):
         tagcheck = await TagCheck.get_or_none(channel_id=channel_id)
         if tagcheck:
             await tagcheck.delete()
+
 

--- a/src/cogs/esports/events/tags.py
+++ b/src/cogs/esports/events/tags.py
@@ -113,7 +113,7 @@ class TagEvents(Cog):
                 self.bot.loop.create_task(delete_denied_message(msg, 60))
 
     @Cog.listener(name="on_guild_channel_delete")
-    async def on_channel_delete(self, channel: discord.abc.GuildChannel):
+    async def on_channel_delete(self, channel: discord.TextChannel):
         channel_id = channel.id
 
         # Delete EasyTag record if exists
@@ -125,3 +125,4 @@ class TagEvents(Cog):
         tagcheck = await TagCheck.get_or_none(channel_id=channel_id)
         if tagcheck:
             await tagcheck.delete()
+

--- a/src/cogs/esports/events/tags.py
+++ b/src/cogs/esports/events/tags.py
@@ -111,3 +111,17 @@ class TagEvents(Cog):
             if eztag.delete_after:
                 self.bot.loop.create_task(delete_denied_message(message, 60))
                 self.bot.loop.create_task(delete_denied_message(msg, 60))
+
+    @Cog.listener(name="on_guild_channel_delete")
+    async def on_channel_delete(self, channel: discord.abc.GuildChannel):
+        channel_id = channel.id
+
+        # Delete EasyTag record if exists
+        easytag = await EasyTag.get_or_none(channel_id=channel_id)
+        if easytag:
+            await easytag.delete()
+
+        # Delete TagCheck record if exists
+        tagcheck = await TagCheck.get_or_none(channel_id=channel_id)
+        if tagcheck:
+            await tagcheck.delete()


### PR DESCRIPTION
Added an `on_channel_delete` event listener that checks for EasyTag and TagCheck records associated with the deleted channel and deletes them if found.