### PR TITLE
#129 exported tourney data before deleting

### DIFF
--- a/src/cogs/esports/views/tourney/_buttons.py
+++ b/src/cogs/esports/views/tourney/_buttons.py
@@ -390,7 +390,7 @@ class DeleteTourney(TourneyButton):
         if not prompt:
             return await self.ctx.simple("Okay, not deleting.", 3)
 
-        await self.view.record.full_delete()
+        await self.view.record.full_delete(interaction.user)
         await self.ctx.success("Successfully deleted tourney.", 3)
 
         from .main import TourneyManager as TM

--- a/src/cogs/utility/views/embeds.py
+++ b/src/cogs/utility/views/embeds.py
@@ -18,7 +18,11 @@ class EmbedSend(discord.ui.Button):
         super().__init__(label="Send to #{0}".format(channel.name), style=discord.ButtonStyle.green)
 
     async def callback(self, interaction: discord.Interaction) -> T.Any:
-        try:
+        user = interaction.user
+        if not self.channel.permissions_for(user).send_messages:
+            return await interaction.response.send_message(f"You do not have the `send_messages` permission for the {self.channel.mention} channel.")
+
+        try: 
             m: T.Optional[discord.Message] = await self.channel.send(embed=self.view.embed)
 
         except Exception as e:

--- a/src/models/esports/tourney.py
+++ b/src/models/esports/tourney.py
@@ -45,7 +45,6 @@ class Tourney(BaseDbModel):
 
     slotlist_start = fields.SmallIntField(default=2)
     group_size = fields.SmallIntField(null=True)
-
     success_message = fields.CharField(max_length=500, null=True)
 
     emojis = fields.JSONField(default=_dict)
@@ -232,7 +231,15 @@ class Tourney(BaseDbModel):
 
         return discord.File(fp, filename=f"tourney_data_{self.id}_{self.bot.current_time.timestamp()}.csv")
 
-    async def full_delete(self) -> None:
+    async def full_delete(self, member:discord.Member=None) -> None:
+        if self.logschan != None:
+            member = member.mention if member else "Unknown"
+            embed = discord.Embed(color=discord.Color.red())
+            embed.title=f"A tournament was completely deleted."
+            embed.description=f"Tourney name : {self.name} [{self.id}]" + f"\nDeleted by: {member}"
+            await self.logschan.send(embed=embed,file=await self.get_csv())
+
+ 
         self.bot.cache.tourney_channels.discard(self.registration_channel_id)
         _data = await self.assigned_slots.all()
         await TMSlot.filter(pk__in=[_.id for _ in _data]).delete()


### PR DESCRIPTION


Fixes #129 

### Description:
Added embed that's sent when an interaction to delete is caused or when a tournament is ended.

___

### Checklist:
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.



