### PR TITLE
referenced channel id instead  of channel

### DIFF
--- a/src/models/esports/scrims.py
+++ b/src/models/esports/scrims.py
@@ -479,7 +479,7 @@ class Scrim(BaseDbModel):
         from .slotm import ScrimsSlotManager
 
         _id = self.pk
-        self.bot.cache.scrim_channels.discard(self.registration_channel.id)
+        self.bot.cache.scrim_channels.discard(self.registration_channel_id)
 
         slotm = await ScrimsSlotManager.filter(guild_id=self.guild_id, scrim_ids__contains=self.pk)
         await ScrimsSlotManager.filter(pk__in=[_.pk for _ in slotm]).update(scrim_ids=ArrayRemove("scrim_ids", _id))


### PR DESCRIPTION
## Fixes #150 

### Description:
replaced ```scrim.registration_channel.id``` with ```scrim.registration_channel_id``` to prevent AttributeError when a scrim is deleted without registration channel

___

### Checklist:
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.



